### PR TITLE
Wrong Code in example in Programmer's guide

### DIFF
--- a/tensorflow/docs_src/programmers_guide/variables.md
+++ b/tensorflow/docs_src/programmers_guide/variables.md
@@ -205,7 +205,7 @@ methods:
 v = tf.get_variable("v", shape=(), initializer=tf.zeros_initializer())
 assignment = v.assign_add(1)
 tf.global_variables_initializer().run()
-assignment.run()
+assignment.eval()
 ```
 
 Most TensorFlow optimizers have specialized ops that efficiently update the


### PR DESCRIPTION
In Programmer's guide Variable section
the `assignment` variable is a `tf.Tensor` and should use `.eval()` instead of  `.run()`

Otherwise, this code would produce an error:
```
AttributeError: 'Tensor' object has no attribute 'run'
```